### PR TITLE
Fix EST tests and OpenSSL CMP integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,15 @@ ebin/
 .elixir_ls/
 ca.log
 mix.lock
+csr/
+*.csr
+/synrc
+/keys
+/openssl
+/.idea
+.tool-versions
+/*-packs
+*.sh
+*.pem
+*.enc
+*.ovpn

--- a/lib/services/http/post.ex
+++ b/lib/services/http/post.ex
@@ -51,44 +51,12 @@ defmodule CA.EST.Post do
     |> send_resp()
   end
 
-  def parse_csr(body) do
-    case :public_key.pem_decode(body) do
-      [{:CertificationRequest, bin, _} | _] ->
-        :"PKCS-10".decode(:CertificationRequest, bin)
-      _ ->
-        case :"PKCS-10".decode(:CertificationRequest, body) do
-          {:ok, csr} ->
-            {:ok, csr}
-          _ ->
-            try do
-              clean_body = String.replace(body, ~r/\s+/, "")
-              decoded = :base64.decode(clean_body)
-              :"PKCS-10".decode(:CertificationRequest, decoded)
-            rescue
-              _ -> {:error, :invalid_csr}
-            end
-        end
-    end
-  end
-
-  defp try_valid_csr(csr) do
-    try do
-      X509.CSR.valid?(csr)
-    rescue
-      _ -> false
-    catch
-      _ -> false
-    end
-  end
-
-  def post(conn, "CA", curve, template, op) when op in ["ENROLL", "RE-ENROLL"] do
+  def post(conn, "CA", curve, _template, op) when op in ["ENROLL", "RE-ENROLL"] do
     {:ok, body, _} = Plug.Conn.read_body(conn, [])
 
     case parse_csr(body) do
       {:ok, csr} ->
         curve_name = if curve in @profiles, do: curve, else: CA.RDN.profile(csr)
-        template_name = if template in @classes, do: template, else: "client"
-
         if curve_name in @profiles do
           {ca_key, ca} = CA.CSR.read_ca(curve_name)
           subject = CA.RDN.decodeAttrs(X509.CSR.subject(csr))
@@ -149,5 +117,35 @@ defmodule CA.EST.Post do
 
   def post(conn, _, curve, _template, op) when curve in @profiles do
     send_resp(conn, 200, CA.EST.encode(%{"curve" => curve, "operation" => op}))
+  end
+
+  def parse_csr(body) do
+    case :public_key.pem_decode(body) do
+      [{:CertificationRequest, bin, _} | _] ->
+        :"PKCS-10".decode(:CertificationRequest, bin)
+      _ ->
+        case :"PKCS-10".decode(:CertificationRequest, body) do
+          {:ok, csr} ->
+            {:ok, csr}
+          _ ->
+            try do
+              clean_body = String.replace(body, ~r/\s+/, "")
+              decoded = :base64.decode(clean_body)
+              :"PKCS-10".decode(:CertificationRequest, decoded)
+            rescue
+              _ -> {:error, :invalid_csr}
+            end
+        end
+    end
+  end
+
+  defp try_valid_csr(csr) do
+    try do
+      X509.CSR.valid?(csr)
+    rescue
+      _ -> false
+    catch
+      _ -> false
+    end
   end
 end

--- a/test/cmp_test.exs
+++ b/test/cmp_test.exs
@@ -17,6 +17,7 @@ defmodule CA.CMPTest do
     {:ok, key: key_path, csr: csr_path, cert: cert_path}
   end
 
+  @tag :openssl_cmp
   test "CMP certificate enrollment (p10cr) using openssl client", %{key: key_path, csr: csr_path, cert: cert_path} do
     cn = "maxim-#{:crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)}-cmp"
 

--- a/test/cmp_test.exs
+++ b/test/cmp_test.exs
@@ -22,15 +22,14 @@ defmodule CA.CMPTest do
     cn = "maxim-#{:crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)}-cmp"
 
     # 1. Generate EC private key
-    {_, 0} = System.cmd("openssl", ["ecparam", "-name", "secp384r1", "-genkey", "-noout", "-out", key_path], cd: @openssl_dir)
+    {_, 0} = CA.Test.OpenSSL.cmd(["ecparam", "-name", "secp384r1", "-genkey", "-noout", "-out", key_path], cd: @openssl_dir)
 
     # 2. Generate PKCS#10 CSR
-    {_, 0} = System.cmd("openssl", ["req", "-new", "-key", key_path, "-out", csr_path, "-subj", "/C=UA/ST=Kyiv/O=SYNRC/CN=#{cn}"], cd: @openssl_dir)
+    {_, 0} = CA.Test.OpenSSL.cmd(["req", "-new", "-key", key_path, "-out", csr_path, "-subj", "/C=UA/ST=Kyiv/O=SYNRC/CN=#{cn}"], cd: @openssl_dir)
 
     # 3. Call openssl cmp to issue the certificate
     # The server is already running under supervision on port 8829
-    {output, status} = System.cmd(
-      "openssl",
+    {output, status} = CA.Test.OpenSSL.cmd(
       [
         "cmp",
         "-cmd", "p10cr",
@@ -54,7 +53,7 @@ defmodule CA.CMPTest do
     assert File.exists?(cert_path)
 
     # 4. Verify the issued certificate contains the correct subject
-    {cert_info, 0} = System.cmd("openssl", ["x509", "-noout", "-subject", "-in", cert_path], cd: @openssl_dir)
+    {cert_info, 0} = CA.Test.OpenSSL.cmd(["x509", "-noout", "-subject", "-in", cert_path], cd: @openssl_dir)
     assert cert_info =~ "CN=#{cn}"
   end
 end

--- a/test/est_test.exs
+++ b/test/est_test.exs
@@ -12,8 +12,8 @@ defmodule CA.ESTTest do
     cn = "maxim-#{:crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)}-est"
 
     # Generate a fresh EC key and a CSR (PEM)
-    {_, 0} = System.cmd("openssl", ["ecparam", "-name", "secp384r1", "-genkey", "-noout", "-out", key_path], cd: @openssl_dir)
-    {_, 0} = System.cmd("openssl", ["req", "-new", "-key", key_path, "-out", csr_path, "-subj", "/C=UA/ST=Kyiv/O=SYNRC/CN=#{cn}"], cd: @openssl_dir)
+    {_, 0} = CA.Test.OpenSSL.cmd(["ecparam", "-name", "secp384r1", "-genkey", "-noout", "-out", key_path], cd: @openssl_dir)
+    {_, 0} = CA.Test.OpenSSL.cmd(["req", "-new", "-key", key_path, "-out", csr_path, "-subj", "/C=UA/ST=Kyiv/O=SYNRC/CN=#{cn}"], cd: @openssl_dir)
 
     pem_csr = File.read!(csr_path)
     [{:CertificationRequest, der_csr, _}] = :public_key.pem_decode(pem_csr)

--- a/test/est_test.exs
+++ b/test/est_test.exs
@@ -62,73 +62,55 @@ defmodule CA.ESTTest do
     end
   end
 
+  defp est_request!(csr_path, path) do
+    {response, status} =
+      System.cmd("curl", [
+        "-sS", "-i",
+        "-X", "POST",
+        "-H", "Content-Type: application/pkcs10",
+        "--data-binary", "@" <> csr_path,
+        "http://127.0.0.1:8047" <> path
+      ], stderr_to_stdout: true)
+
+    assert status == 0, "curl failed with status #{status}:\n#{response}"
+
+    {headers, body} = parse_curl_response(response)
+    normalized_headers = String.downcase(headers)
+
+    assert normalized_headers =~ "http/1.1 200",
+           "EST request failed. Response headers:\n#{headers}\nResponse body:\n#{body}"
+
+    assert normalized_headers =~ "content-type: application/pkcs7-mime",
+           "Unexpected EST content type. Response headers:\n#{headers}\nResponse body:\n#{body}"
+
+    assert normalized_headers =~ "content-transfer-encoding: base64",
+           "EST response is not Base64 encoded. Response headers:\n#{headers}\nResponse body:\n#{body}"
+
+    body
+  end
+
   test "EST simpleenroll with PEM CSR", %{pem_path: csr_path, cn: cn} do
-    # Call curl with headers and body
-    {res, 0} = System.cmd("curl", [
-      "-s", "-i",
-      "-X", "POST",
-      "-H", "Content-Type: application/pkcs10",
-      "--data-binary", "@" <> csr_path,
-      "http://127.0.0.1:8047/.well-known/est/simpleenroll"
-    ])
-
-    {headers, body} = parse_curl_response(res)
-
-    assert String.downcase(headers) =~ "content-type: application/pkcs7-mime"
-    assert String.downcase(headers) =~ "content-transfer-encoding: base64"
-
+    body = est_request!(csr_path, "/.well-known/est/simpleenroll")
     verify_est_response!(body, cn)
   end
 
   test "EST simpleenroll with raw DER CSR", %{der_path: der_path, cn: cn} do
-    {res, 0} = System.cmd("curl", [
-      "-s", "-i",
-      "-X", "POST",
-      "-H", "Content-Type: application/pkcs10",
-      "--data-binary", "@" <> der_path,
-      "http://127.0.0.1:8047/.well-known/est/simpleenroll"
-    ])
-
-    {_headers, body} = parse_curl_response(res)
+    body = est_request!(der_path, "/.well-known/est/simpleenroll")
     verify_est_response!(body, cn)
   end
 
   test "EST simpleenroll with Base64 CSR", %{base64_path: base64_path, cn: cn} do
-    {res, 0} = System.cmd("curl", [
-      "-s", "-i",
-      "-X", "POST",
-      "-H", "Content-Type: application/pkcs10",
-      "--data-binary", "@" <> base64_path,
-      "http://127.0.0.1:8047/.well-known/est/simpleenroll"
-    ])
-
-    {_headers, body} = parse_curl_response(res)
+    body = est_request!(base64_path, "/.well-known/est/simpleenroll")
     verify_est_response!(body, cn)
   end
 
   test "EST simpleenroll with explicit profile in URL", %{pem_path: csr_path, cn: cn} do
-    {res, 0} = System.cmd("curl", [
-      "-s", "-i",
-      "-X", "POST",
-      "-H", "Content-Type: application/pkcs10",
-      "--data-binary", "@" <> csr_path,
-      "http://127.0.0.1:8047/.well-known/est/secp384r1-client/simpleenroll"
-    ])
-
-    {_headers, body} = parse_curl_response(res)
+    body = est_request!(csr_path, "/.well-known/est/secp384r1-client/simpleenroll")
     verify_est_response!(body, cn)
   end
 
   test "EST simplereenroll with PEM CSR", %{pem_path: csr_path, cn: cn} do
-    {res, 0} = System.cmd("curl", [
-      "-s", "-i",
-      "-X", "POST",
-      "-H", "Content-Type: application/pkcs10",
-      "--data-binary", "@" <> csr_path,
-      "http://127.0.0.1:8047/.well-known/est/simplereenroll"
-    ])
-
-    {_headers, body} = parse_curl_response(res)
+    body = est_request!(csr_path, "/.well-known/est/simplereenroll")
     verify_est_response!(body, cn)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,58 @@
+defmodule CA.Test.OpenSSL do
+  @moduledoc false
+
+  def executable do
+    System.get_env("OPENSSL3") ||
+      System.get_env("OPENSSL") ||
+      System.find_executable("openssl") ||
+      "openssl"
+  end
+
+  def cmd(args, opts \\ []) do
+    System.cmd(executable(), args, Keyword.put(opts, :env, command_env()))
+  end
+
+  def cmp_available? do
+    case cmd(["list", "-commands"], stderr_to_stdout: true) do
+      {commands, 0} ->
+        commands
+        |> String.split()
+        |> Enum.member?("cmp")
+
+      _ ->
+        false
+    end
+  end
+
+  defp command_env do
+    library_paths = openssl_library_paths()
+
+    case library_paths do
+      [] ->
+        []
+
+      paths ->
+        current = System.get_env("LD_LIBRARY_PATH", "")
+        value = Enum.join(paths ++ nonempty(current), ":")
+        [{"LD_LIBRARY_PATH", value}]
+    end
+  end
+
+  defp openssl_library_paths do
+    prefix =
+      executable()
+      |> Path.expand()
+      |> Path.dirname()
+      |> Path.dirname()
+
+    [Path.join(prefix, "lib64"), Path.join(prefix, "lib")]
+    |> Enum.filter(&File.dir?/1)
+  end
+
+  defp nonempty(""), do: []
+  defp nonempty(value), do: [value]
+end
+
 backend = System.get_env("KVS_BACKEND", "mnesia")
 
 excludes =
@@ -7,25 +62,8 @@ excludes =
     _ -> []
   end
 
-openssl_cmp_available? =
-  case System.find_executable("openssl") do
-    nil ->
-      false
-
-    openssl ->
-      case System.cmd(openssl, ["list", "-commands"], stderr_to_stdout: true) do
-        {commands, 0} ->
-          commands
-          |> String.split()
-          |> Enum.member?("cmp")
-
-        _ ->
-          false
-      end
-  end
-
 excludes =
-  if openssl_cmp_available? do
+  if CA.Test.OpenSSL.cmp_available?() do
     excludes
   else
     IO.puts("OpenSSL CMP command is unavailable; excluding :openssl_cmp integration tests")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,4 +7,29 @@ excludes =
     _ -> []
   end
 
+openssl_cmp_available? =
+  case System.find_executable("openssl") do
+    nil ->
+      false
+
+    openssl ->
+      case System.cmd(openssl, ["list", "-commands"], stderr_to_stdout: true) do
+        {commands, 0} ->
+          commands
+          |> String.split()
+          |> Enum.member?("cmp")
+
+        _ ->
+          false
+      end
+  end
+
+excludes =
+  if openssl_cmp_available? do
+    excludes
+  else
+    IO.puts("OpenSSL CMP command is unavailable; excluding :openssl_cmp integration tests")
+    [:openssl_cmp | excludes]
+  end
+
 ExUnit.start(exclude: excludes)


### PR DESCRIPTION
- fixed EST test diagnostics and response validation
- made OpenSSL CMP tests capability-aware
- added shared OpenSSL test runner with OPENSSL3/OPENSSL support
- removed EST handler warnings
- verified all tests locally